### PR TITLE
Fix startup and setup scripts being set to None

### DIFF
--- a/testflows/github/hetzner/runners/config/config.py
+++ b/testflows/github/hetzner/runners/config/config.py
@@ -655,9 +655,11 @@ def check_setup_script(script: str):
     """Check if setup script is valid."""
     if not os.path.exists(script):
         raise SetupScriptError(f"invalid setup script path '{script}'")
+    return script
 
 
 def check_startup_script(script: str):
     """Check if startup script is valid."""
     if not os.path.exists(script):
         raise StartupScriptError(f"invalid startup script path '{script}'")
+    return script


### PR DESCRIPTION
When checking if scripts exist, they are being set to None.