### PR TITLE
Fix incorrect type hint and error in recyclable_server_match

### DIFF
--- a/testflows/github/hetzner/runners/scale_up.py
+++ b/testflows/github/hetzner/runners/scale_up.py
@@ -516,7 +516,7 @@ def max_servers_in_workflow_run_reached(
 
 
 def recyclable_server_match(
-    server: BoundServer,
+    server: RunnerServer,
     server_type: ServerType,
     server_location: Location,
     server_net_config: ServerCreatePublicNetwork,
@@ -530,16 +530,16 @@ def recyclable_server_match(
     if server_location and server.server_location.name != server_location.name:
         return False
 
-    if server_net_config.enable_ipv4 and server.public_net.ipv4 is None:
+    if server_net_config.enable_ipv4 and server.server.public_net.ipv4 is None:
         return False
 
-    if not server_net_config.enable_ipv4 and server.public_net.ipv4 is not None:
+    if not server_net_config.enable_ipv4 and server.server.public_net.ipv4 is not None:
         return False
 
-    if server_net_config.enable_ipv6 and server.public_net.ipv6 is None:
+    if server_net_config.enable_ipv6 and server.server.public_net.ipv6 is None:
         return False
 
-    if not server_net_config.enable_ipv6 and server.public_net.ipv6 is not None:
+    if not server_net_config.enable_ipv6 and server.server.public_net.ipv6 is not None:
         return False
 
     return ssh_key.name == server.server.labels.get(server_ssh_key_label)


### PR DESCRIPTION
```
14:37:30 ❌ AttributeError: 'RunnerServer' object has no attribute 'public_net'
14:37:30 ❌ AttributeError: 'RunnerServer' object has no attribute 'public_net'
14:37:30 ❗ Error: AttributeError 'RunnerServer' object has no attribute 'public_net'
```
Error results from the server object not being what is expected from the type hint.