### PR TITLE
Fix: add self-hosted label to standby_runners config block

### DIFF
--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -44,6 +44,7 @@ config:
     # standby runners groups configuration
     standby_runners:
         - labels:
+            - self-hosted
             - type-cpx21
           count: 3
           replenish_immediately: true


### PR DESCRIPTION
It seems the config.yaml example is missing the `self-hosted` label for standby runners, which causes them to constantly get re-provisioned after timeouts are reached. They are never detected as ready as they are missing the label. When a job is scheduled, new runners end up being created and the standby runners are ignored. With the label added, standby runners immediately pick up CI jobs as expected.